### PR TITLE
Create crunch42-analysis.yml

### DIFF
--- a/crunch42-analysis.yml
+++ b/crunch42-analysis.yml
@@ -1,0 +1,53 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+# This workflow locates REST API file contracts
+# (Swagger or OpenAPI format, v2 and v3, JSON and YAML)
+# and runs 200+ security checks on them using 42Crunch Security Audit technology.
+#
+# Documentation is located here: https://docs.42crunch.com/latest/content/tasks/integrate_github_actions.htm
+#
+# To use this workflow, you will need to complete the following setup steps.
+#
+# 1. Create a free 42Crunch account at https://platform.42crunch.com/register
+#
+# 2. Follow steps at https://docs.42crunch.com/latest/content/tasks/integrate_github_actions.htm
+#    to create an API Token on the 42Crunch platform
+#
+# 3. Add a secret in GitHub as explained in https://docs.42crunch.com/latest/content/tasks/integrate_github_actions.htm,
+#    store the 42Crunch API Token in that secret, and supply the secret's name as api-token parameter in this workflow
+#
+# If you have any questions or need help contact https://support.42crunch.com
+
+name: "42Crunch REST API Static Security Testing"
+
+# follow standard Code Scanning triggers
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ master ]
+  schedule:
+    - cron: '16 13 * * 0'
+
+jobs:
+  rest-api-static-security-testing:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: 42Crunch REST API Static Security Testing
+        uses: 42Crunch/api-security-audit-action@96228d9c48873fe001354047d47fb62be42abeb1
+        with:
+          # Please create free account at https://platform.42crunch.com/register
+          # Follow these steps to configure API_TOKEN https://docs.42crunch.com/latest/content/tasks/integrate_github_actions.htm
+          api-token: ${{ secrets.API_TOKEN }}
+          # Fail if any OpenAPI file scores lower than 75
+          min-score: 75
+          # Upload results to Github code scanning
+          upload-to-code-scanning: true
+          # Github token for uploading the results
+          github-token: ${{ github.token }}


### PR DESCRIPTION
# This workflow uses actions that are not certified by GitHub.
# They are provided by a third-party and are governed by
# separate terms of service, privacy policy, and support
# documentation.

# This workflow locates REST API file contracts
# (Swagger or OpenAPI format, v2 and v3, JSON and YAML)
# and runs 200+ security checks on them using 42Crunch Security Audit technology.
#
# Documentation is located here: https://docs.42crunch.com/latest/content/tasks/integrate_github_actions.htm
#
# To use this workflow, you will need to complete the following setup steps.
#
# 1. Create a free 42Crunch account at https://platform.42crunch.com/register
#
# 2. Follow steps at https://docs.42crunch.com/latest/content/tasks/integrate_github_actions.htm
#    to create an API Token on the 42Crunch platform
#
# 3. Add a secret in GitHub as explained in https://docs.42crunch.com/latest/content/tasks/integrate_github_actions.htm,
#    store the 42Crunch API Token in that secret, and supply the secret's name as api-token parameter in this workflow
#
# If you have any questions or need help contact https://support.42crunch.com

name: "42Crunch REST API Static Security Testing"

# follow standard Code Scanning triggers
on:
  push:
    branches: [ master ]
  pull_request:
    # The branches below must be a subset of the branches above
    branches: [ master ]
  schedule:
    - cron: '16 13 * * 0'

jobs:
  rest-api-static-security-testing:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v2

      - name: 42Crunch REST API Static Security Testing
        uses: 42Crunch/api-security-audit-action@96228d9c48873fe001354047d47fb62be42abeb1
        with:
          # Please create free account at https://platform.42crunch.com/register
          # Follow these steps to configure API_TOKEN https://docs.42crunch.com/latest/content/tasks/integrate_github_actions.htm
          api-token: ${{ secrets.API_TOKEN }}
          # Fail if any OpenAPI file scores lower than 75
          min-score: 75
          # Upload results to Github code scanning
          upload-to-code-scanning: true
          # Github token for uploading the results
          github-token: ${{ github.token }}
